### PR TITLE
Add package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "private": true,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "files": [
+    "lib/"
+  ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "clean": "tsc --build tsconfig.build.json --clean",


### PR DESCRIPTION
This simply adds the files setting to `package.json` to ensure only allowed files are packaged. It may also help with `yarn` not installing properly with git dependencies.